### PR TITLE
Automate dictionary quarterly snapshot updates

### DIFF
--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -1,0 +1,20 @@
+on: [push]
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    name: 'Extracts and prepares Freelex data for use by native applications'
+    steps:
+      - uses: actions/checkout@v2
+      - run: make build update_assets
+      - uses: actions/upload-artifact@v2
+        with:
+          name: assets
+          path: assets
+      - uses: actions/upload-artifact@v2
+        with:
+          name: nzsl.dat
+          path: nzsl.dat
+      - uses: actions/upload-artifact@v2
+        with:
+          name: nzsl.db
+          path: nzsl.db

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -7,10 +7,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: make build update_assets
       - run: tar -cf assets.tar.gz assets
-  release:
-    runs-on: ubuntu-latest
-    name: "Create release using extracted Freelex data"
-    steps:
       - name: Create Release
         uses: actions/create-release@v1
         env:

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  schedule:
+  # Run quarterly - Jan, Mar, Jun, Sept, at 1PM UTC (~ 1AM NZT)
+  - cron: "0 13 * 1,3,6,9 *"
 jobs:
   extract:
     runs-on: ubuntu-latest

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -4,6 +4,9 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Extracts and prepares Freelex data for use by native applications'
     steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - uses: actions/checkout@v2
       - run: make build update_assets
       - run: tar -cf assets.tar.gz assets
@@ -12,10 +15,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          tag_name: ${{steps.date.outputs.date}}
+          release_name: Quarterly release as at ${{steps.date.outputs.date}}
           body: |
-            Quarterly release of NZSL Dictionary data
+            Every quarter, the native dictionary applications are updated from the main 
+            NZSL Dictionary from this release. If you wish to use a 'snapshot' of the dictionary,
+            these files may be useful. 
+
+            NZSL Dictionary data by Deaf Studies Research Unit, Victoria University of Wellington is licensed under 
+            a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
           draft: false
           prerelease: false
       - name: Upload Release Asset

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -11,6 +11,7 @@ jobs:
       - run: make build update_assets
       - run: tar -cf assets.tar.gz assets
       - name: Create Release
+        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -6,15 +6,46 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: make build update_assets
-      - uses: actions/upload-artifact@v2
+      - run: tar -cf assets.tar.gz assets
+  release:
+    runs-on: ubuntu-latest
+    name: "Create release using extracted Freelex data"
+    steps:
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          name: assets
-          path: assets
-      - uses: actions/upload-artifact@v2
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Quarterly release of NZSL Dictionary data
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: nzsl.dat
-          path: nzsl.dat
-      - uses: actions/upload-artifact@v2
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: ./assets.tar.gz
+          asset_name: assets.tar.gz
+          asset_content_type: application/gzip
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: nzsl.db
-          path: nzsl.db
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./nzsl.db
+          asset_name: nzsl.db
+          asset_content_type: application/vnd.sqlite3
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./nzsl.dat
+          asset_name: nzsl.dat
+          asset_content_type: text/plain

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+RUN apt-get update &&\
+    apt-get install -qqy imagemagick optipng &&\
+    mkdir /usr/src/app &&\
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+
+ENTRYPOINT ["python", "build-assets.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 build:
-	  docker build . -t rabid/nzsl-dictionary-scripts
-		git clone git://github.com/rabid/nzsl-dictionary-ios.git
-		git clone git://github.com/rabid/nzsl-dictionary-android.git
+	  docker build . -t odnzsl/nzsl-dictionary-scripts
 update_assets:
-	docker run --rm -it -v $(shell pwd)/nzsl-dictionary-android:/usr/src/android-app -v $(shell pwd)/nzsl-dictionary-ios:/usr/src/ios-app -v $(shell pwd):/usr/src/app rabid/nzsl-dictionary-scripts -i /usr/src/ios-app -a /usr/src/android-app
+	docker run --rm -it -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts 
 	 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
 	  docker build . -t odnzsl/nzsl-dictionary-scripts
 update_assets:
-	docker run --rm -it -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts 
+	docker run --rm -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts 
 	 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python3 ./build-assets.py -i "/path/to/nzsl-dictionary-ios" -a "/path/to/nzsl-di
 
 ## build-assets.py
 
-This is a wholistic script that performs all the steps needed to get all the necessary assets from the NZSL Freelex server. It does a number of steps:
+This is a holistic script that performs all the steps needed to get all the necessary assets from the NZSL Freelex server. It does a number of steps:
 
 * Step 1: Fetching the latest signs from Freelex
 * Step 2: Fetching images from Freelex

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ cd /path/to/this/repo
 python3 ./build-assets.py 
 ```
 
+Expect this process to take between 2 and 4 hours.
+
 ## build-assets.py
 
 This is a holistic script that performs all the steps needed to get all the necessary assets from the NZSL Freelex server. It does a number of steps:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 This repository holds scripts that are useful for the creation of the NZSL Android and iOS applications.
 
-## Dependencies
 
-These scripts use some commands you will need to have available for a successful run
+## Build - Docker
+
+A Dockerfile is provided in this repository to make it easier to run the scripts. A Makefile is provided with
+some very simple commands to build and run the image.
+
+You can run `make build update_assets` to build the Docker image and then generate the assets and database files.
+Expect this process to take between 2 and 4 hours.
+
+## Build - Non-Docker
+
+To build without Docker, there are some dependencies you will need to have available on your PATH.
 
 ### python3
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ sudo apt-get install optipng
 ```
 cd /path/to/this/repo
 
-# you must provide both AND android and an iOS path
-python3 ./build-assets.py -i "/path/to/nzsl-dictionary-ios" -a "/path/to/nzsl-dictionary-android"
+python3 ./build-assets.py 
 ```
 
 ## build-assets.py
@@ -78,7 +77,9 @@ This is a holistic script that performs all the steps needed to get all the nece
 * Step 6b: Shrink images for distribution
 * Step 7: Cleanup (optional, requires -c flag)
 
-To call the script you must provide the iOS and Android app base paths. The end result is your apps are updated with the latest sign databases and images, ready for building.
+At the end of this process, you will find pictures (diagrams + search thumbnails), in the 'assets/` folder, and the
+application databases in 'nzsl.dat' and 'nzsl.db'. The content of the two data files is the same, but they represent the 
+data in different formats.
 
 ## freelex.py
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository holds scripts that are useful for the creation of the NZSL Android and iOS applications.
 
+## Quick access to assets
+
+An scheduled build runs quarterly to produce the assets and data files for the NZSL Dictionary applications to use.
+If you are after these assets and are not interested in the absolute latest data, you can download these files without
+having to wait for them to build from the [Releases](https://github.com/odnzsl/nzsl-dictionary-scripts/releases) tab.
 
 ## Build - Docker
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,7 @@ This is a wholistic script that performs all the steps needed to get all the nec
 * Step 6: Merge images together into one folder
 * Step 6a: Generate search thumbnails
 * Step 6b: Shrink images for distribution
-* Step 7a: Update iOS app images
-* Step 7b: Update iOS app nzsl.db
-* Step 8a: Update Android app images
-* Step 8b: Update Android app nzsl.dat
-* Step 9: Cleanup (optional, requires -c flag)
+* Step 7: Cleanup (optional, requires -c flag)
 
 To call the script you must provide the iOS and Android app base paths. The end result is your apps are updated with the latest sign databases and images, ready for building.
 

--- a/build-assets.py
+++ b/build-assets.py
@@ -88,7 +88,7 @@ for path, dirs, files in os.walk("assets/"):
         os.system(optipng_cmd)
 
 if options.cleanup:
-    print("Step 9: Cleanup")
+    print("Step 7: Cleanup")
     os.remove("dnzsl-xmldump.xml")
     os.remove("nzsl.dat")
     os.remove("nzsl.db")

--- a/build-assets.py
+++ b/build-assets.py
@@ -12,27 +12,9 @@ def print_run_msg(msg):
     print(" - Running: " + msg)
 
 parser = OptionParser()
-parser.add_option("-i", "--ios",
-                  help="location of iOS app root", metavar="IOS_PATH")
-parser.add_option("-a", "--android",
-                  help="location of Android app root", metavar="ANDROID_PATH")
 parser.add_option("-c", action="store_true", dest="cleanup", help="clean up files after execution")
 
 (options, args) = parser.parse_args()
-
-if (options.ios == None or options.android == None):
-    print("Missing iOS or Android path, please see build-assets.py -h")
-    sys.exit(1)
-
-if (os.path.isdir(options.ios) == False or
-    os.path.exists(options.ios + '/NZSLDict/main.m') == False):
-    print("Invalid iOS path")
-    sys.exit(1)
-
-if (os.path.isdir(options.android) == False or
-    os.path.exists(options.android + '/build.gradle') == False):
-    print("Invalid Android path")
-    sys.exit(1)
 
 filename = 'dnzsl-xmldump.xml'
 
@@ -104,53 +86,6 @@ for path, dirs, files in os.walk("assets/"):
         optipng_cmd = "optipng -quiet assets/" + filename
         print_run_msg(optipng_cmd)
         os.system(optipng_cmd)
-
-print("Step 7a: Update iOS app images")
-
-ios_asset_path = options.ios + "/Data/picture/"
-
-if os.path.isdir(ios_asset_path):
-    shutil.rmtree(ios_asset_path)
-
-os.makedirs(ios_asset_path)
-
-# re-create the .gitkeep file in the assets dir (it is not necessary for the
-# app but keeps that dir in the git repo)
-os.system("touch " + ios_asset_path + ".gitkeep")
-
-for path, dirs, files in os.walk("assets/"):
-    for filename in files:
-        cp_cmd = "cp assets/" + filename + " " + ios_asset_path
-        print_run_msg(cp_cmd)
-        os.system(cp_cmd)
-
-print("Step 7b: Update iOS app nzsl.db")
-os.system("cp nzsl.db " + options.ios + "/Data/")
-
-print("Step 8a: Update Android app images")
-android_asset_path = options.android + "/app/src/main/assets/images/signs/"
-
-if os.path.isdir(android_asset_path):
-    shutil.rmtree(android_asset_path)
-
-os.makedirs(android_asset_path)
-
-# re-create the .gitkeep file in the assets dir (it is not necessary for the
-# app but keeps that dir in the git repo)
-os.system("touch " + android_asset_path + ".gitkeep")
-
-for path, dirs, files in os.walk("assets/"):
-    for filename in files:
-        cp_cmd = "cp assets/" + filename + " " + android_asset_path
-        print_run_msg(cp_cmd)
-        os.system(cp_cmd)
-
-print("Step 8b: Update Android app nzsl.dat")
-android_db_path = options.android + "/app/src/main/assets/db/"
-if not os.path.exists(android_db_path):
-    os.makedirs(android_db_path)
-
-os.system("cp nzsl.dat " + android_db_path)
 
 if options.cleanup:
     print("Step 9: Cleanup")


### PR DESCRIPTION
This pull request leverages Github Actions to build assets and dictionary database files from Freelex and releases these file via the Releases tab on Github, making the files available for download.

The most significant change here is removing the idea of updating the Android and iOS applications inline with the script run. I've been doing dictionary updates on the native apps for a number of years now, and feel this is not the right thing for this repository to be doing for a number of reasons:

1. It's a mixture of concerns 
2. To follow through with those app updates still requires full build tooling for Android and iOS to be set up
3. It doesn't obviously export artefacts other than the two updated repositories

I believe that a smoother workflow is to abstract the applications from these scripts, so the scripts produce the imagery and databases that are used by the applications as releases, and the applications then consume the release to update themselves. This also allows us to direct powerusers who wish to have a snapshot of dictionary data to work with to easily access and download the data they need from these same releases. 

I have made Dockerfiles and Makefiles available to make it easier for users to produce their own set of assets and dictionary files if they wish. Github actions is set to run quarterly, on the 1st of January, March, June and September, producing a release using the current date each time. Note that these builds run on UTC time. I have set the time to 13 hours offset, to ensure that server load is during the night in NZ, but the actual builds will be run the day after NZ. I've opted to not offset the dates back to keep the tag and release names nice round numbers (since GH Actions creates the tag and release in UTC time)

An example of a completed build can be found at https://github.com/odnzsl/nzsl-dictionary-scripts/actions/runs/207998964
The corresponding release is at https://github.com/ODNZSL/nzsl-dictionary-scripts/releases/tag/2020-08-15
