### PR TITLE
Only run Signbank extraction on schedule now that we have a stable extraction script

### DIFF
--- a/.github/workflows/signbank-extract.yml
+++ b/.github/workflows/signbank-extract.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   schedule:
   # Run monthly at 1PM UTC (~ 1AM NZT)
   - cron: 0 13 1 * *

--- a/.github/workflows/signbank-extract.yml
+++ b/.github/workflows/signbank-extract.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - feature/export-from-signbank
   schedule:
   # Run monthly at 1PM UTC (~ 1AM NZT)
   - cron: 0 13 1 * *


### PR DESCRIPTION
While we were tweaking the Signbank extraction process, it was useful to run a build when we made a change, but we have things pretty stable now, so we can revert back to a scheduled build.
