### PR TITLE
Define a primary key on the words table, and use ON CONFLICT to ignore duplicate rows

### DIFF
--- a/signbank.py
+++ b/signbank.py
@@ -204,7 +204,7 @@ def write_sqlitefile(data, database_filename):
         """
         create table words (
           gloss, minor, maori, picture, video, handshape, location, location_identifier, variant_number, target, age_groups,
-          contains_numbers boolean, hint, id, inflection_manner_and_degree boolean, inflection_plural boolean,
+          contains_numbers boolean, hint, id PRIMARY KEY, inflection_manner_and_degree boolean, inflection_plural boolean,
           inflection_temporal boolean, is_directional boolean, is_fingerspelling boolean, is_locatable boolean,
           one_or_two_handed boolean, related_to, usage, usage_notes, word_classes, gloss_normalized,
           minor_normalized, maori_normalized
@@ -260,7 +260,7 @@ def write_sqlitefile(data, database_filename):
               :gloss_normalized,
               :minor_normalized,
               :maori_normalized
-            )
+            ) ON CONFLICT DO NOTHING
           """, entry)
         add_examples(entry, db)
         add_topics(entry, db)


### PR DESCRIPTION
This pull request uses SQLite3 ON CONFLICT syntax to ignore rows that already exist in the `words` table. The cause of the duplicates is due to an upstream issue with the Signbank export process, probably due to a OUTER JOIN somewhere yielding duplicate rows (examples?)

This change defines a PRIMARY KEY on the words table - this is a schema change, but should not upset any downstream users of the database, since (for Ackama-managed apps anyway), we already treat the ID as a primary key. This is required for ON CONFLICT to work. 

ON CONFLICT requires SQLite version 3.24.0 (~2018). There is an older version of ON CONFLICT from 2004 that can raise errors since the syntax following is different. Just noting that in case we run into any versions of SQLite old enough to buy themselves a drink 🍻 

With the de-duplication, we process 4954 signs
Without the de-duplication, we process 4964 signs