### PR TITLE
Add support for a --skip-assets option which will not download and process sign media

### DIFF
--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -1,0 +1,25 @@
+
+on:
+  # Must be run manually
+  workflow_dispatch:
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    name: 'Extracts and prepares Signbank database data, bypassing asset processing'
+    steps:
+      - uses: actions/checkout@v2
+      - run: make build update_signbank_database
+        env:
+          SIGNBANK_HOST: ${{ secrets.SIGNBANK_HOST }}
+          SIGNBANK_USERNAME: ${{ secrets.SIGNBANK_USERNAME }}
+          SIGNBANK_PASSWORD: ${{ secrets.SIGNBANK_PASSWORD }}
+      - name: Upload nzsl.db
+        uses: actions/upload-artifact@v2
+        with:
+          name: nzsl.db
+          path: ./nzsl.db
+      - name: Upload nzsl.dat
+        uses: actions/upload-artifact@v2
+        with:
+          name: nzsl.dat
+          path: ./nzsl.dat

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,6 @@ update_freelex_assets:
 	docker run --rm -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts build-assets-from-freelex.py
 update_signbank_assets:
 	docker run -e SIGNBANK_HOST -e SIGNBANK_USERNAME -e SIGNBANK_PASSWORD --rm -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts build-assets-from-signbank.py
+update_signbank_database:
+	docker run -e SIGNBANK_HOST -e SIGNBANK_USERNAME -e SIGNBANK_PASSWORD --rm -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts build-assets-from-signbank.py --skip-assets
 

--- a/build-assets-from-signbank.py
+++ b/build-assets-from-signbank.py
@@ -10,6 +10,7 @@ from log import print_run_msg
 parser = OptionParser()
 parser.add_option("-c", action="store_true", dest="cleanup",
                   help="clean up files after execution")
+parser.add_option("--skip-assets", action="store_true", help="Export Signbank data, but not supporting media", dest="skip_assets")
 
 (options, args) = parser.parse_args()
 
@@ -19,6 +20,7 @@ dat_file_filename = "nzsl.dat"
 database_filename = 'nzsl.db'
 assets_folder = 'signbank-assets'
 pictures_folder = 'assets'
+download = not options.skip_assets
 
 print("Step 1: Fetching the latest signs from Signbank")
 signbank.fetch_gloss_export_file(filename)
@@ -32,16 +34,17 @@ signbank.write_sqlitefile(data, database_filename)
 print("Step 4: Fetching assets from signbank")
 signbank.fetch_gloss_asset_export_file(video_filename)
 asset_data = signbank.parse_signbank_csv(video_filename)
-signbank.fetch_gloss_assets(asset_data, database_filename, assets_folder)
+signbank.fetch_gloss_assets(asset_data, database_filename, assets_folder, download=download)
 
 print("Step 4: Write out nzsl.dat for Android")
 signbank.write_datfile(database_filename, dat_file_filename)
 
-print("Step 5: Merge images together into one folder")
-signbank.copy_images_to_one_folder(assets_folder, pictures_folder)
+if download:
+    print("Step 5: Merge images together into one folder")
+    signbank.copy_images_to_one_folder(assets_folder, pictures_folder)
 
-print("Step 6: Prepare images for distribution")
-image_processing.process_images(pictures_folder)
+    print("Step 6: Prepare images for distribution")
+    image_processing.process_images(pictures_folder)
 
 if options.cleanup:
     print("Step 7: Cleanup")

--- a/signbank.py
+++ b/signbank.py
@@ -118,7 +118,7 @@ def fetch_gloss_assets(data, database_filename, output_folder, download=True):
 
         # We don't need to download videos, just know where they are
         if download and filename.endswith(".png"):
-            if download and  not os.path.exists(filename):
+            if download and not os.path.exists(filename):
                 asset_request = get_from_s3(entry['Videofile'])
                 with open(filename, "wb") as asset_file:
                     asset_file.write(asset_request.content)

--- a/signbank.py
+++ b/signbank.py
@@ -82,8 +82,8 @@ def fetch_gloss_asset_export_file(filename):
         f.write(video_response.content)
 
 
-def fetch_gloss_assets(data, database_filename, output_folder):
-    if not os.path.exists(output_folder):
+def fetch_gloss_assets(data, database_filename, output_folder, download=True):
+    if not os.path.exists(output_folder) and download:
         os.makedirs(output_folder)
 
     db = sqlite3.connect(database_filename)
@@ -117,15 +117,15 @@ def fetch_gloss_assets(data, database_filename, output_folder):
             continue
 
         # We don't need to download videos, just know where they are
-        if filename.endswith(".png"):
-            if not os.path.exists(filename):
+        if download and filename.endswith(".png"):
+            if download and  not os.path.exists(filename):
                 asset_request = get_from_s3(entry['Videofile'])
                 with open(filename, "wb") as asset_file:
                     asset_file.write(asset_request.content)
                 print("downloaded", end=", ")
             else:
                 print("already downloaded", end=", ")
-        else:
+        elif download:
             print("not an image, skipping download", end=", ")
 
         # Update the words table with the picture, if this is an image and of type main


### PR DESCRIPTION
This pull request adds an option to the Signbank extractor so that if `--skip-assets` is provided, sign media will be recorded in the database, but will not be downloaded or processed (resized, compressed, etc).

This drastically speeds up the import process, taking 20 seconds when I tested locally instead of over an hour. The database files produced are otherwise identical to what a full export produces, they just do not have the supporting assets. These can still be downloaded as required based on data in the database, and in fact this is exactly what NZSL Share and the NZSL Dictionary already do - only the native apps require the supporting media to be exported.

This PR adds support for the option, but does not alter the scheduled release process yet. It's intended that this style of release could be used as a preview, nightly, or on-demand workflow to allow for preview of unreleased content.