### PR TITLE
Add support for exporting a prerelease database

### DIFF
--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -23,3 +23,9 @@ jobs:
         with:
           name: nzsl.dat
           path: ./nzsl.dat
+      - run: make build update_signbank_prerelease_database
+        env:
+          SIGNBANK_HOST: ${{ secrets.SIGNBANK_HOST }}
+          SIGNBANK_USERNAME: ${{ secrets.SIGNBANK_USERNAME }}
+          SIGNBANK_PASSWORD: ${{ secrets.SIGNBANK_PASSWORD }}
+          SIGNBANK_WEB_READY_TAG_ID: ${{ vars.SIGNBANK_WEB_READY_TAG_ID }}

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,8 @@ update_signbank_assets:
 	docker run -e SIGNBANK_HOST -e SIGNBANK_USERNAME -e SIGNBANK_PASSWORD --rm -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts build-assets-from-signbank.py
 update_signbank_database:
 	docker run -e SIGNBANK_HOST -e SIGNBANK_USERNAME -e SIGNBANK_PASSWORD --rm -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts build-assets-from-signbank.py --skip-assets
+update_signbank_prerelease_database:
+	docker run -e SIGNBANK_HOST -e SIGNBANK_USERNAME -e SIGNBANK_PASSWORD -e SIGNBANK_WEB_READY_TAG_ID --rm -v $(shell pwd):/usr/src/app odnzsl/nzsl-dictionary-scripts build-assets-from-signbank.py --skip-assets --prerelease
+
+
 

--- a/build-assets-from-signbank.py
+++ b/build-assets-from-signbank.py
@@ -11,6 +11,9 @@ parser = OptionParser()
 parser.add_option("-c", action="store_true", dest="cleanup",
                   help="clean up files after execution")
 parser.add_option("--skip-assets", action="store_true", help="Export Signbank data, but not supporting media", dest="skip_assets")
+parser.add_option("--prerelease", action="store_true",
+                                  help="Export prerelease Signbank data rather than published data",
+                                  dest="prerelease")
 
 (options, args) = parser.parse_args()
 
@@ -22,8 +25,14 @@ assets_folder = 'signbank-assets'
 pictures_folder = 'assets'
 download = not options.skip_assets
 
+filters = {}
+if options.prerelease:
+    filters['tags'] = signbank.SIGNBANK_WEB_READY_TAG_ID
+else:
+    filters['published'] = 'on'
+
 print("Step 1: Fetching the latest signs from Signbank")
-signbank.fetch_gloss_export_file(filename)
+signbank.fetch_gloss_export_file(filename, filters)
 data = signbank.parse_signbank_csv(filename)
 
 

--- a/signbank.py
+++ b/signbank.py
@@ -13,6 +13,7 @@ DEFAULT_SIGNBANK_HOST = os.getenv("SIGNBANK_HOST", "https://signbank.nzsl.nz")
 SIGNBANK_DATASET_ID = os.getenv("SIGNBANK_DATASET_ID", 1)
 SIGNBANK_USERNAME = os.getenv("SIGNBANK_USERNAME")
 SIGNBANK_PASSWORD = os.getenv("SIGNBANK_PASSWORD")
+SIGNBANK_WEB_READY_TAG_ID = os.getenv("SIGNBANK_WEB_READY_TAG_ID")
 
 ##
 # Start a requests session that is authenticated to Signbank
@@ -57,10 +58,10 @@ def get_from_s3(key):
 ##########################
 
 
-def fetch_gloss_export_file(filename):
+def fetch_gloss_export_file(filename, filters = {}):
     session = signbank_session()
     response = session.get("%s/dictionary/advanced/" % DEFAULT_SIGNBANK_HOST,
-                           params={"dataset": SIGNBANK_DATASET_ID, "published": 'on', "format": 'CSV'})
+                           params={**filters, "dataset": SIGNBANK_DATASET_ID, "format": 'CSV'})
     response.raise_for_status()
     with open(filename, "wb") as f:
         f.write(response.content)


### PR DESCRIPTION
This pull request adds another option to the Signbank export which alters the filters applied to the Signbank export. This exports signs which have the Web ready: Passed tag in Signbank, indicating that they are in a final check stage, but are not yet published. 

The intent is to use this database in preproduction environments, allowing Signbank editorial staff to run the dictionary database export workflow to export the prerelease database and update the pre-production environments.

