### PR TITLE
Persist the current YYYYMMDD in the user_version PRAGMA metadata store of the output SQLite database

### DIFF
--- a/signbank.py
+++ b/signbank.py
@@ -6,6 +6,7 @@ import sqlite3
 import time
 
 import requests
+from datetime import datetime
 from requests.adapters import HTTPAdapter, Retry
 from urllib3.exceptions import ProtocolError
 
@@ -211,6 +212,10 @@ def write_sqlitefile(data, database_filename):
     if os.path.exists(database_filename):
         os.unlink(database_filename)
     db = sqlite3.connect(database_filename)
+
+    version = datetime.utcnow().strftime("%Y%m%d")
+    db.execute(f"PRAGMA user_version = {version}")
+
     db.execute(
         """
         create table words (


### PR DESCRIPTION
This pull request stores the release date of the database in YYYYMMDD format using the [`user_version`](https://www.sqlite.org/pragma.html#pragma_user_version) PRAGMA setting. This is a space allocated by SQLite specifically for an integral version number. 

The intent is for consumers of the database to be able to use this version to display the release date to end users, so it is understood which release version is being used at that time to fetch and display results.

After export:

```bash
sqlite3 nzsl.db
SQLite version 3.39.5 2022-10-14 20:58:05
Enter ".help" for usage hints.
sqlite> PRAGMA user_version;
20231211
```