### PR TITLE
Upload Signbank database to AWS S3

### DIFF
--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -17,9 +17,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: $${ env.AWS_ROLE_ARN }}
+          role-to-assume: $${ secrets.AWS_ROLE_ARN }}
           role-session-name: nzsl-dictionary-scripts-extract
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
       - uses: actions/checkout@v2
       - name: Export Signbank database
         run: |
@@ -38,7 +38,7 @@ jobs:
           SIGNBANK_WEB_READY_TAG_ID: ${{ vars.SIGNBANK_WEB_READY_TAG_ID }}
       - name: Upload nzsl.db to S3
         run: |
-          aws s3 cp ./nzsl.db s3://${{ env.AWS_S3_BUCKET_NAME }}/${{ env.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl=${{ env.AWS_S3_DEPLOYMENT_ACL }}}
+          aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl=${{ secrets.AWS_S3_DEPLOYMENT_ACL }}}
       - name: Upload nzsl.db
         if: github.event.inputs.environment == 'Production'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           role-to-assume: "${ secrets.AWS_ROLE_ARN }}"
           role-session-name: nzsl-dictionary-scripts-extract
-          aws-region: "${{ vars.AWS_REGION }}"
+          aws-region: "${{ vars.AWS_ROLE_REGION }}"
       - name: Export Signbank database
         run: |
           if [[ "${{ github.event.inputs.environment }}" == "Production" ]]; then

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     name: "Extracts and prepares Signbank database data, bypassing asset processing"
     steps:
+      - uses: actions/checkout@v2
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: $${ secrets.AWS_ROLE_ARN }}
+          role-to-assume: "${ secrets.AWS_ROLE_ARN }}"
           role-session-name: nzsl-dictionary-scripts-extract
-          aws-region: ${{ vars.AWS_REGION }}
-      - uses: actions/checkout@v2
+          aws-region: "${{ vars.AWS_REGION }}"
       - name: Export Signbank database
         run: |
           if [[ "${{ github.event.inputs.environment }}" == "Production" ]]; then

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -13,6 +13,7 @@ jobs:
   extract:
     runs-on: ubuntu-latest
     name: "Extracts and prepares Signbank database data, bypassing asset processing"
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v2
       - name: Configure AWS Credentials
@@ -20,7 +21,7 @@ jobs:
         with:
           role-to-assume: "${{ secrets.AWS_ROLE_ARN }}"
           role-session-name: nzsl-dictionary-scripts-extract
-          aws-region: ap-southeast-2
+          aws-region: "${{ vars.AWS_ROLE_REGION }}"
       - name: Export Signbank database
         run: |
           if [[ "${{ github.event.inputs.environment }}" == "Production" ]]; then

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -39,7 +39,7 @@ jobs:
           SIGNBANK_WEB_READY_TAG_ID: ${{ vars.SIGNBANK_WEB_READY_TAG_ID }}
       - name: Upload nzsl.db to S3
         run: |
-          aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl=${{ secrets.AWS_S3_DEPLOYMENT_ACL }}}
+          aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl ${{ secrets.AWS_S3_DEPLOYMENT_ACL }}}
       - name: Upload nzsl.db
         if: github.event.inputs.environment == 'Production'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           role-to-assume: "${{ secrets.AWS_ROLE_ARN }}"
           role-session-name: nzsl-dictionary-scripts-extract
-          aws-region: "${{ vars.AWS_ROLE_REGION }}"
+          aws-region: "${{ vars.AWS_REGION }}"
       - name: Export Signbank database
         run: |
           if [[ "${{ github.event.inputs.environment }}" == "Production" ]]; then

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           role-to-assume: "${ secrets.AWS_ROLE_ARN }}"
           role-session-name: nzsl-dictionary-scripts-extract
-          aws-region: "${{ vars.AWS_ROLE_REGION }}"
+          aws-region: ap-southeast-2
       - name: Export Signbank database
         run: |
           if [[ "${{ github.event.inputs.environment }}" == "Production" ]]; then

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: "${ secrets.AWS_ROLE_ARN }}"
+          role-to-assume: "${{ secrets.AWS_ROLE_ARN }}"
           role-session-name: nzsl-dictionary-scripts-extract
           aws-region: ap-southeast-2
       - name: Export Signbank database

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -39,7 +39,7 @@ jobs:
           SIGNBANK_WEB_READY_TAG_ID: ${{ vars.SIGNBANK_WEB_READY_TAG_ID }}
       - name: Upload nzsl.db to S3
         run: |
-          aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl ${{ secrets.AWS_S3_DEPLOYMENT_ACL }}}
+          aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl ${{ secrets.AWS_S3_DEPLOYMENT_ACL }}
       - name: Upload nzsl.db
         if: github.event.inputs.environment == 'Production'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -1,31 +1,53 @@
-
 on:
   # Must be run manually
   workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to export Signbank data to"
+        type: environment
+        required: true
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
 jobs:
   extract:
     runs-on: ubuntu-latest
-    name: 'Extracts and prepares Signbank database data, bypassing asset processing'
+    name: "Extracts and prepares Signbank database data, bypassing asset processing"
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: $${ env.AWS_ROLE_ARN }}
+          role-session-name: nzsl-dictionary-scripts-extract
+          aws-region: ${{ env.AWS_REGION }}
       - uses: actions/checkout@v2
-      - run: make build update_signbank_database
-        env:
-          SIGNBANK_HOST: ${{ secrets.SIGNBANK_HOST }}
-          SIGNBANK_USERNAME: ${{ secrets.SIGNBANK_USERNAME }}
-          SIGNBANK_PASSWORD: ${{ secrets.SIGNBANK_PASSWORD }}
-      - name: Upload nzsl.db
-        uses: actions/upload-artifact@v2
-        with:
-          name: nzsl.db
-          path: ./nzsl.db
-      - name: Upload nzsl.dat
-        uses: actions/upload-artifact@v2
-        with:
-          name: nzsl.dat
-          path: ./nzsl.dat
-      - run: make build update_signbank_prerelease_database
+      - name: Export Signbank database
+        run: |
+          if [[ "${{ github.event.inputs.environment }}" == "Production" ]]; then
+            make build update_signbank_database
+          elif [[ "${{ github.event.inputs.environment }}" == "Prerelease" ]]; then
+            make build update_signbank_prerelease_database
+          else
+            echo "Unknown environment: ${{ github.event.inputs.environment }}"
+            exit 1
+          fi
         env:
           SIGNBANK_HOST: ${{ secrets.SIGNBANK_HOST }}
           SIGNBANK_USERNAME: ${{ secrets.SIGNBANK_USERNAME }}
           SIGNBANK_PASSWORD: ${{ secrets.SIGNBANK_PASSWORD }}
           SIGNBANK_WEB_READY_TAG_ID: ${{ vars.SIGNBANK_WEB_READY_TAG_ID }}
+      - name: Upload nzsl.db to S3
+        run: |
+          aws s3 cp ./nzsl.db s3://${{ env.AWS_S3_BUCKET_NAME }}/${{ env.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl=${{ env.AWS_S3_DEPLOYMENT_ACL }}}
+      - name: Upload nzsl.db
+        if: github.event.inputs.environment == 'Production'
+        uses: actions/upload-artifact@v2
+        with:
+          name: nzsl.db
+          path: ./nzsl.db
+      - name: Upload nzsl.dat
+        if: github.event.inputs.environment == 'Production'
+        uses: actions/upload-artifact@v2
+        with:
+          name: nzsl.dat
+          path: ./nzsl.dat


### PR DESCRIPTION
This pull request pairs with https://github.com/ODNZSL/nzsl-infrastructure/pull/3 to automatically publish prerelease or production Signbank databases to the appropriate S3 bucket (UAT or Production).

I've adjusted the dictionary export workflow so that an environment must be specified - either Prerelease or Production. Based on the input environment, the workflow exports either a prerelease or production database, uploads it to S3, and if it's a production build, outputs the resulting database as a build artifact on the actions run. 

An example of a prerelease run, with the file uploaded to S3:

https://github.com/ODNZSL/nzsl-dictionary-scripts/actions/runs/7201324009

![image](https://github.com/ODNZSL/nzsl-dictionary-scripts/assets/292020/9760375a-19f3-4649-b00d-232b884a9376)

An example of a production run, with the attached artifcacts and file uploaded to S3:

https://github.com/ODNZSL/nzsl-dictionary-scripts/actions/runs/7201414593

![image](https://github.com/ODNZSL/nzsl-dictionary-scripts/assets/292020/d24ae5c2-1694-498a-9443-d4982c4ed504)

![image](https://github.com/ODNZSL/nzsl-dictionary-scripts/assets/292020/3ade42c3-7fc8-4a27-809f-1529d48b0465)

A neat thing about environments is that they can have branch protection rules attached to them. This prevents workflows that use that environment from running unless it meets the protection rules. As an example, I've activated a branch protection rule that only allows the workflow to be run against the 'main' branch, as shown in this build:

https://github.com/ODNZSL/nzsl-dictionary-scripts/actions/runs/7201433151

![image](https://github.com/ODNZSL/nzsl-dictionary-scripts/assets/292020/ff51bda3-de71-4827-bcf1-b15d332195d9)

Once this PR is merged, I'd recommend we put the same rule in place for the prerelease export.

**Note:** I will of course squash merge, this was more iterative than I had planned 😆 