### PR TITLE
Extract private, non-published assets from Signbank, then prune unused asssets

### DIFF
--- a/build-assets-from-signbank.py
+++ b/build-assets-from-signbank.py
@@ -41,7 +41,7 @@ signbank.write_sqlitefile(data, database_filename)
 
 
 print("Step 4: Fetching assets from signbank")
-signbank.fetch_gloss_asset_export_file(video_filename)
+signbank.fetch_gloss_asset_export_file(video_filename, { 'include_private': options.prerelease })
 asset_data = signbank.parse_signbank_csv(video_filename)
 signbank.fetch_gloss_assets(asset_data, database_filename, assets_folder, download=download)
 

--- a/build-assets-from-signbank.py
+++ b/build-assets-from-signbank.py
@@ -44,6 +44,7 @@ print("Step 4: Fetching assets from signbank")
 signbank.fetch_gloss_asset_export_file(video_filename, { 'include_private': options.prerelease })
 asset_data = signbank.parse_signbank_csv(video_filename)
 signbank.fetch_gloss_assets(asset_data, database_filename, assets_folder, download=download)
+signbank.prune_orphan_assets(database_filename)
 
 print("Step 4: Write out nzsl.dat for Android")
 signbank.write_datfile(database_filename, dat_file_filename)

--- a/signbank.py
+++ b/signbank.py
@@ -80,7 +80,8 @@ def parse_signbank_csv(filename):
 ##########################
 def fetch_gloss_asset_export_file(filename):
     session = signbank_session()
-    video_response = session.get("%s/video/csv" % DEFAULT_SIGNBANK_HOST)
+
+    video_response = session.get("%s/video/csv" % DEFAULT_SIGNBANK_HOST, params=filters)
     video_response.raise_for_status()
     with open(filename, "wb") as f:
         f.write(video_response.content)

--- a/signbank.py
+++ b/signbank.py
@@ -78,7 +78,7 @@ def parse_signbank_csv(filename):
 ##########################
 # Asset handling
 ##########################
-def fetch_gloss_asset_export_file(filename):
+def fetch_gloss_asset_export_file(filename, filters = {}):
     session = signbank_session()
 
     video_response = session.get("%s/video/csv" % DEFAULT_SIGNBANK_HOST, params=filters)
@@ -172,6 +172,20 @@ def fetch_gloss_assets(data, database_filename, output_folder, download=True):
 
 # Modify filenames to match the Android requirements (lowercase a-z and _ only)
 # Since iOS uses the same underlying data, update iOS to use the same image names.
+
+
+def prune_orphan_assets(database_filename):
+    db = sqlite3.connect(database_filename)
+    cursor = db.cursor()
+    cursor.execute(
+        """
+        DELETE FROM videos
+        WHERE word_id NOT IN (SELECT word_id FROM words);
+        """
+    )
+    deleted_records = cursor.rowcount
+    print(f"Pruned {deleted_records} assets not associated with a word")
+
 
 
 def normalize_asset_filename(filename):

--- a/signbank.py
+++ b/signbank.py
@@ -22,8 +22,8 @@ SIGNBANK_WEB_READY_TAG_ID = os.getenv("SIGNBANK_WEB_READY_TAG_ID")
 
 def signbank_session():
     s = requests.Session()
-    s.get("%s/accounts/login/" % DEFAULT_SIGNBANK_HOST)
-    s.post("%s/accounts/login/" % DEFAULT_SIGNBANK_HOST,
+    s.get(f"{DEFAULT_SIGNBANK_HOST}/accounts/login/")
+    s.post(f"{DEFAULT_SIGNBANK_HOST}/accounts/login/",
            data={'username': SIGNBANK_USERNAME, 'password': SIGNBANK_PASSWORD,
                  'csrfmiddlewaretoken': s.cookies['csrftoken']},
            headers={'Referer': DEFAULT_SIGNBANK_HOST})
@@ -61,7 +61,7 @@ def get_from_s3(key):
 
 def fetch_gloss_export_file(filename, filters = {}):
     session = signbank_session()
-    response = session.get("%s/dictionary/advanced/" % DEFAULT_SIGNBANK_HOST,
+    response = session.get(f"{DEFAULT_SIGNBANK_HOST}/dictionary/advanced/",
                            params={**filters, "dataset": SIGNBANK_DATASET_ID, "format": 'CSV'})
     response.raise_for_status()
     with open(filename, "wb") as f:
@@ -81,7 +81,7 @@ def parse_signbank_csv(filename):
 def fetch_gloss_asset_export_file(filename, filters = {}):
     session = signbank_session()
 
-    video_response = session.get("%s/video/csv" % DEFAULT_SIGNBANK_HOST, params=filters)
+    video_response = session.get(f"{DEFAULT_SIGNBANK_HOST}/video/csv", params=filters)
     video_response.raise_for_status()
     with open(filename, "wb") as f:
         f.write(video_response.content)


### PR DESCRIPTION
This pull request adds two features:

1. Requests private, non-public assets from Signbank (this requires https://github.com/ODNZSL/NZSL-signbank/pull/130 to work, but it doesn't make the script break, it just only gets public assets - i.e. what it does without this PR)
2. Prunes any assets that don't have a corresponding entry in the words table.

This makes the export a little simpler, because the word extraction can have whatever filters and rules we need to get the right data for the environment, then we can over-request assets for those words, and just strip any assets that we don't use.

