### PR TITLE
NZSL-157: Update the Signbank database extraction task to automatically restart Heroku apps after a release is performed 

### DIFF
--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -52,3 +52,7 @@ jobs:
         with:
           name: nzsl.dat
           path: ./nzsl.dat
+      - name: Restart Heroku application(s)
+        run: |
+            heroku restart --app ${{ secrets.HEROKU_DICTIONARY_APP_NAME }} --api-token ${{ secrets.HEROKU_DICTIONARY_API_TOKEN }}
+            heroku restart --app ${{ secrets.HEROKU_SHARE_APP_NAME }} --api-token ${{ secrets.HEROKU_SHARE_API_TOKEN }}

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -53,7 +53,6 @@ jobs:
           name: nzsl.dat
           path: ./nzsl.dat
       - name: Restart Heroku application(s)
-        environment:
         run: |
             HEROKU_API_KEY=${{ secrets.HEROKU_DICTIONARY_API_TOKEN }} heroku restart --app ${{ secrets.HEROKU_DICTIONARY_APP_NAME }}
             HEROKU_API_KEY=${{ secrets.HEROKU_SHARE_API_TOKEN }} heroku restart --app ${{ secrets.HEROKU_SHARE_APP_NAME }}

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -53,6 +53,7 @@ jobs:
           name: nzsl.dat
           path: ./nzsl.dat
       - name: Restart Heroku application(s)
+        environment:
         run: |
-            heroku restart --app ${{ secrets.HEROKU_DICTIONARY_APP_NAME }} --api-token ${{ secrets.HEROKU_DICTIONARY_API_TOKEN }}
-            heroku restart --app ${{ secrets.HEROKU_SHARE_APP_NAME }} --api-token ${{ secrets.HEROKU_SHARE_API_TOKEN }}
+            HEROKU_API_KEY=${{ secrets.HEROKU_DICTIONARY_API_TOKEN }} heroku restart --app ${{ secrets.HEROKU_DICTIONARY_APP_NAME }}
+            HEROKU_API_KEY=${{ secrets.HEROKU_SHARE_API_TOKEN }} heroku restart --app ${{ secrets.HEROKU_SHARE_APP_NAME }}


### PR DESCRIPTION
This pull request adds an additional step to the database extraction task so that Heroku apps are automatically restarted following a database extraction. The apps to restart are determined by values in secrets, which are further determined by environment. For example, when the environment is 'prerelease', the staging and UAT apps will be restarted. When the environment is 'production', the production apps will be restarted.

Each of the apps being restarted either has, or will have a process to download the latest dictionary database (which has just been published by this workflow) upon starting.
