### PR TITLE
NZSL-176: Don't export private videos as part of the prerelease export

### DIFF
--- a/build-assets-from-signbank.py
+++ b/build-assets-from-signbank.py
@@ -41,7 +41,7 @@ signbank.write_sqlitefile(data, database_filename)
 
 
 print("Step 4: Fetching assets from signbank")
-signbank.fetch_gloss_asset_export_file(video_filename, { 'include_private': options.prerelease })
+signbank.fetch_gloss_asset_export_file(video_filename)
 asset_data = signbank.parse_signbank_csv(video_filename)
 signbank.fetch_gloss_assets(asset_data, database_filename, assets_folder, download=download)
 signbank.prune_orphan_assets(database_filename)


### PR DESCRIPTION
This pull request reverts a feature added that would apply a filter for prerelease exports to export private videos. We've since determined that private videos should never leave signbank, since they are used for multiple reasons, but are not intended to be displayed in a public context unless they are specifically made public. We can leave the capability to pass filters in place, since the arg default for this is `{}`.