### PR TITLE
fix: update csv format name

### DIFF
--- a/signbank.py
+++ b/signbank.py
@@ -62,7 +62,7 @@ def get_from_s3(key):
 def fetch_gloss_export_file(filename, filters = {}):
     session = signbank_session()
     response = session.get(f"{DEFAULT_SIGNBANK_HOST}/dictionary/advanced/",
-                           params={**filters, "dataset": SIGNBANK_DATASET_ID, "format": 'CSV'})
+                           params={**filters, "dataset": SIGNBANK_DATASET_ID, "format": 'CSV-standard'})
     response.raise_for_status()
     with open(filename, "wb") as f:
         f.write(response.content)


### PR DESCRIPTION
As part of [implementing support for an alternative type of CSV export](https://github.com/ODNZSL/NZSL-signbank/commit/b072d8c864a3f9ca5946662833ce12a6885adbdc), the names for the original format was changed in signbank from `CSV` to `CSV-standard`.

This updates the signbank script to use that new key so we'll resume getting CSVs instead of HTML files