### PR TITLE
ci: upgrade `aws-actions/configure-aws-credentials` to v4

### DIFF
--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "${{ secrets.AWS_ROLE_ARN }}"
           role-session-name: nzsl-dictionary-scripts-extract


### PR DESCRIPTION
This is the latest version of the action - the main notable change is that it no longer marks the AWS account ID as secret so it won't be masked in logs, which is fine as it isn't a secret 🤷 