### PR TITLE
ci: upgrade `actions/upload-artifact` to v4

### DIFF
--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -42,13 +42,13 @@ jobs:
           aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl ${{ secrets.AWS_S3_DEPLOYMENT_ACL }}
       - name: Upload nzsl.db
         if: github.event.inputs.environment == 'Production'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nzsl.db
           path: ./nzsl.db
       - name: Upload nzsl.dat
         if: github.event.inputs.environment == 'Production'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: nzsl.dat
           path: ./nzsl.dat


### PR DESCRIPTION
This takes us to the latest major version of this action since previous versions are hard deprecated meaning the pipelines currently won't run.

This is due to v4 introducing a new way of handling artifacts that has underlying infrastructure changes and performance improvements at the cost of artifacts being immutable; this change doesn't impact us though as we're not relying on artifact merging.