### PR TITLE
ci: ensure `heroku` cli is installed

### DIFF
--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           name: nzsl.dat
           path: ./nzsl.dat
+      - run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
       - name: Restart Heroku application(s)
         run: |
             HEROKU_API_KEY=${{ secrets.HEROKU_DICTIONARY_API_TOKEN }} heroku restart --app ${{ secrets.HEROKU_DICTIONARY_APP_NAME }}


### PR DESCRIPTION
The GHA ubuntu-24.04 runner image no longer includes the Heroku CLI, so we have to install it manually.

Also see https://github.com/actions/runner-images/issues/10636